### PR TITLE
Bugfix apetrov php deprecated error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.4.3 (3 Oct 2025)
+
+* [*] Internal improvements.
+
 # 1.4.2 (6 May 2024)
 
 * [-] The "PHP Deprecated Construction: Creation of dynamic property Modules_WebsiteVirusCheck_PleskDomain" error no longer appears in /var/log/plesk/panel.log in Plesk for Linux and in %plesk_dir%\admin\logs\php_error.log in Plesk for Windows. (EXTPLESK-5512)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # 1.4.3 (3 Oct 2025)
 
-* [-] Updated the extension to be fully compatible with PHP 8.4.
+* [*] Updated the extension to be fully compatible with PHP 8.4.
 
 # 1.4.2 (6 May 2024)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # 1.4.3 (3 Oct 2025)
 
-* [*] Internal improvements.
+* [-] Updated the extension to be fully compatible with PHP 8.4.
 
 # 1.4.2 (6 May 2024)
 

--- a/meta.xml
+++ b/meta.xml
@@ -5,7 +5,7 @@
   <description>Check your websites for viruses automatically using multiple anti-virus engines.</description>
   <description xml:lang="ru-RU">Автоматизируйте бесплатную проверку своих сайтов на вирусы.</description>
   <category>security</category>
-  <version>1.4.2</version>
+  <version>1.4.3</version>
   <release>2</release>
   <vendor>Plesk</vendor>
   <url>https://github.com/plesk/ext-website-virus-check</url>

--- a/plib/library/Helper.php
+++ b/plib/library/Helper.php
@@ -687,7 +687,7 @@ class Modules_WebsiteVirusCheck_Helper
      * @return mixed
      */
     static function getDomainReport($domainId) {
-        $report = json_decode(pm_Settings::get('domain_id_' . $domainId), true);
+        $report = json_decode(pm_Settings::get('domain_id_' . $domainId, ''), true);
         return $report;
     }
 


### PR DESCRIPTION
This PR fixes the error in the `panel.log`
```
[29-Oct-2025 13:42:04 Etc/UTC] PHP Deprecated Construction: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated; File: /opt/ps>

[2025-10-29 13:42:04.294] 2907:690219ac4170e ERR [panel][] Exception: PHP Deprecated Construction: json_decode(): Passing null to parameter #1 ($json) of t>

file: /opt/psa/admin/plib/Smb/Exception/Syntax.php
line: 55
code: 0
trace: #0 (0): Smb_Exception_Syntax::handleError(integer '8192', string 'json_decode(): Passing null to parameter #1 ($json) of type string is deprecated',>
#1 /opt/psa/admin/plib/modules/website-virus-check/library/Helper.php(690): json_decode(NULL null, boolean true)
#2 /opt/psa/admin/plib/modules/website-virus-check/library/Helper.php(473): Modules_WebsiteVirusCheck_Helper::getDomainReport(string '1')
#3 /opt/psa/admin/plib/modules/website-virus-check/controllers/IndexController.php(212): Modules_WebsiteVirusCheck_Helper::getDomainsReport()
#4 /opt/psa/admin/plib/modules/website-virus-check/controllers/IndexController.php(52): IndexController->_getDomainsReportList()
#5 /opt/psa/admin/plib/vendor/plesk/zf1/library/Zend/Controller/Action.php(516): IndexController->reportAction()
#6 /opt/psa/admin/plib/vendor/plesk/zf1/library/Zend/Controller/Dispatcher/Standard.php(308): Zend_Controller_Action->dispatch(string 'reportAction')
#7 /opt/psa/admin/plib/vendor/plesk/zf1/library/Zend/Controller/Front.php(954): Zend_Controller_Dispatcher_Standard->dispatch(object of type Zend_Controlle>
#8 /opt/psa/admin/plib/pm/Application.php(87): Zend_Controller_Front->dispatch()
#9 /opt/psa/admin/htdocs/modules/website-virus-check/index.php(7): pm_Application->run()
```